### PR TITLE
Workaround GH api break around filtering runs by status

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -40,16 +40,28 @@ export async function run(opts: RunOpts): Promise<void> {
 
   const workflow_id = String(current_run.workflow_id)
   try {
-    const {
-      data: {workflow_runs}
-    } = await octokit.rest.actions.listWorkflowRuns({
-      per_page: 100,
-      owner,
-      repo,
-      workflow_id,
-      branch,
-      ...(opts.status && {status: opts.status})
-    })
+    const workflow_runs = await octokit.paginate(
+      octokit.rest.actions.listWorkflowRuns,
+      {
+        per_page: 100,
+        owner,
+        repo,
+        workflow_id,
+        branch
+      },
+      (response, done) => {
+        let res = response.data.workflow_runs
+        if (opts.status) {
+          res = res.filter(resp => resp.status === opts.status)
+        }
+        // Don't actually want to look through all the runs - if we find some matching the status, lets return
+        //
+        if (res.length > 0) {
+          done()
+        }
+        return res
+      }
+    )
 
     let lastCommit = ''
     if (opts.limitToPreviousSuccessfulRunCommit) {


### PR DESCRIPTION
Looks like the github api has subtly broken filtering workflow runs on status.

```
gh api \
  -H "Accept: application/vnd.github+json" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  "/repos/XXX/XXXX/actions/workflows/XXXX/runs?status=waiting&branch=main"
{
  "total_count": 0,
  "workflow_runs": []
}
```
While setting it to other statuses like `cancelled`, `completed` etc. work just fine. (running the above without the status filter returns runs which are in waiting state).

This change uses client side filtering instead.